### PR TITLE
Fix deprecation warning when using rollup > 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ module.exports = function plugin(options = {}) {
 	return {
 		generateBundle(bundleOptions, bundle, isWrite) {
 			let ids = [];
-			for (const moduleId of this.moduleIds) { 
+			for (const moduleId of this.getModuleIds()) { 
 				if (!exclude(moduleId)) { ids.push(moduleId); }
 			}
 


### PR DESCRIPTION
Use function getModuleIds() instead of deprecated direct access to property moduleIds